### PR TITLE
메일 전송 및 인증코드 확인 기능 구현

### DIFF
--- a/auth-service/build.gradle
+++ b/auth-service/build.gradle
@@ -38,6 +38,12 @@ dependencies {
     implementation 'com.sun.xml.bind:jaxb-core:4.0.1'
     // javax.xml.bind
     implementation 'javax.xml.bind:jaxb-api:2.4.0-b180830.0359'
+
+    // encrypt config
+    implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.4'
+
+    // encrypt algorithm
+    implementation 'org.bouncycastle:bcprov-jdk15on:1.70'
 }
 
 tasks.named('test') {

--- a/auth-service/src/main/java/kr/ac/kumoh/whale/authservice/domain/member/mail/api/MailController.java
+++ b/auth-service/src/main/java/kr/ac/kumoh/whale/authservice/domain/member/mail/api/MailController.java
@@ -1,0 +1,34 @@
+package kr.ac.kumoh.whale.authservice.domain.member.mail.api;
+
+import kr.ac.kumoh.whale.authservice.domain.member.mail.serivce.MailService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.crossstore.ChangeSetPersister;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RequiredArgsConstructor
+@RestController
+public class MailController {
+
+    private final MailService mailService;
+
+    @PostMapping("mail/send")
+    public String mailConfirm(@RequestParam String email) throws Exception {
+        String code = mailService.sendSimpleMessage(email);
+        log.debug("인증코드 : " + code);
+        return code;
+    }
+
+    @GetMapping("mail/check")
+    public ResponseEntity<?> compareCode(@RequestParam String code) throws ChangeSetPersister.NotFoundException {
+
+        mailService.verifyCode(code);
+
+        return ResponseEntity.ok().body("인증 성공");
+    }
+}

--- a/auth-service/src/main/java/kr/ac/kumoh/whale/authservice/domain/member/mail/config/MailConfig.java
+++ b/auth-service/src/main/java/kr/ac/kumoh/whale/authservice/domain/member/mail/config/MailConfig.java
@@ -1,0 +1,46 @@
+package kr.ac.kumoh.whale.authservice.domain.member.mail.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+@Configuration
+public class MailConfig {
+
+    @Value("${spring.mail.username}")
+    private String id;
+    @Value("${spring.mail.password}")
+    private String password;
+    @Value("${spring.mail.host}")
+    private String host;
+    @Value("${spring.mail.port}")
+    private int port;
+
+    @Bean
+    public JavaMailSender javaMailService() {
+        JavaMailSenderImpl javaMailSender = new JavaMailSenderImpl();
+
+        javaMailSender.setHost(host); // smtp 서버 주소
+        javaMailSender.setUsername(id); // 설정(발신) 메일 아이디
+        javaMailSender.setPassword(password); // 설정(발신) 메일 패스워드
+        javaMailSender.setPort(port); //smtp port
+        javaMailSender.setJavaMailProperties(getMailProperties()); // 메일 인증서버 정보 가져온다.
+        javaMailSender.setDefaultEncoding("UTF-8");
+        return javaMailSender;
+    }
+
+    private Properties getMailProperties() {
+        Properties properties = new Properties();
+        properties.setProperty("mail.transport.protocol", "smtp"); // 프로토콜 설정
+        properties.setProperty("mail.smtp.auth", "true"); // smtp 인증
+        properties.setProperty("mail.smtp.starttls.enable", "true"); // smtp starttls 사용
+        properties.setProperty("mail.debug", "true"); // 디버그 사용
+        properties.setProperty("mail.smtp.ssl.trust","smtp.naver.com"); // ssl 인증 서버 주소
+        properties.setProperty("mail.smtp.ssl.enable","true"); // ssl 사용
+        return properties;
+    }
+}

--- a/auth-service/src/main/java/kr/ac/kumoh/whale/authservice/domain/member/mail/serivce/MailService.java
+++ b/auth-service/src/main/java/kr/ac/kumoh/whale/authservice/domain/member/mail/serivce/MailService.java
@@ -1,0 +1,92 @@
+package kr.ac.kumoh.whale.authservice.domain.member.mail.serivce;
+
+import kr.ac.kumoh.whale.authservice.global.redis.RedisService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.crossstore.ChangeSetPersister;
+import org.springframework.mail.MailException;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+import javax.mail.MessagingException;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeMessage;
+import java.io.UnsupportedEncodingException;
+import java.util.Random;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class MailService {
+
+    private final JavaMailSender javaMailSender;
+    private final RedisService redisService;
+
+    //인증번호 생성
+    private final String certificateNumber = createKey();
+
+    @Value("${spring.mail.username}")
+    private String id;
+
+    public MimeMessage createMessage(String to)throws MessagingException, UnsupportedEncodingException {
+        log.info("보내는 대상 : "+ to);
+        log.info("인증 번호 : " + certificateNumber);
+        MimeMessage  message = javaMailSender.createMimeMessage();
+
+        message.addRecipients(MimeMessage.RecipientType.TO, to); // to 보내는 대상
+        message.setSubject("Todo-List 회원가입 인증 코드: "); //메일 제목
+
+        // 메일 내용 메일의 subtype을 html로 지정하여 html문법 사용 가능
+        String msg="";
+        msg += "<h1 style=\"font-size: 30px; padding-right: 30px; padding-left: 30px;\">이메일 주소 확인</h1>";
+        msg += "<p style=\"font-size: 17px; padding-right: 30px; padding-left: 30px;\">아래 확인 코드를 회원가입 화면에서 입력해주세요.</p>";
+        msg += "<div style=\"padding-right: 30px; padding-left: 30px; margin: 32px 0 40px;\"><table style=\"border-collapse: collapse; border: 0; background-color: #F4F4F4; height: 70px; table-layout: fixed; word-wrap: break-word; border-radius: 6px;\"><tbody><tr><td style=\"text-align: center; vertical-align: middle; font-size: 30px;\">";
+        msg += certificateNumber;
+        msg += "</td></tr></tbody></table></div>";
+
+        message.setText(msg, "utf-8", "html"); //내용, charset타입, subtype
+        message.setFrom(new InternetAddress(id,"Todo-List")); //보내는 사람의 메일 주소, 보내는 사람 이름
+
+        return message;
+    }
+
+    // 인증코드 만들기
+    public static String createKey() {
+        StringBuffer key = new StringBuffer();
+        Random rnd = new Random();
+
+        for (int i = 0; i < 6; i++) { // 인증코드 6자리
+            key.append((rnd.nextInt(10)));
+        }
+        return key.toString();
+    }
+
+    /*
+        메일 발송
+        sendSimpleMessage의 매개변수로 들어온 to는 인증번호를 받을 메일주소
+        MimeMessage 객체 안에 내가 전송할 메일의 내용을 담아준다.
+        bean으로 등록해둔 javaMailSender 객체를 사용하여 이메일 send
+     */
+    public String sendSimpleMessage(String to)throws Exception {
+        MimeMessage message = createMessage(to);
+        try{
+            redisService.setDataExpire(certificateNumber, to, 60 * 10L); // 유효시간 10분
+            javaMailSender.send(message); // 메일 발송
+        }catch(MailException es){
+            es.printStackTrace();
+            throw new IllegalArgumentException();
+        }
+        return certificateNumber; // 메일로 보냈던 인증 코드를 서버로 리턴
+    }
+
+    public String verifyCode(String code) throws ChangeSetPersister.NotFoundException {
+        String memberEmail = redisService.getData(code);
+        if(memberEmail == null) {
+            throw new ChangeSetPersister.NotFoundException();
+        }
+        redisService.deleteData(code);
+
+        return certificateNumber;
+    }
+}

--- a/auth-service/src/main/java/kr/ac/kumoh/whale/authservice/global/security/JasyptConfigAES.java
+++ b/auth-service/src/main/java/kr/ac/kumoh/whale/authservice/global/security/JasyptConfigAES.java
@@ -1,0 +1,24 @@
+package kr.ac.kumoh.whale.authservice.global.security;
+
+import com.ulisesbocchio.jasyptspringboot.annotation.EnableEncryptableProperties;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.jasypt.encryption.StringEncryptor;
+import org.jasypt.encryption.pbe.PooledPBEStringEncryptor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableEncryptableProperties
+public class JasyptConfigAES {
+
+    @Bean("jasyptEncryptor")
+    public StringEncryptor stringEncryptor() {
+        PooledPBEStringEncryptor encryptor = new PooledPBEStringEncryptor();
+        encryptor.setProvider(new BouncyCastleProvider());
+        encryptor.setPoolSize(2);
+        encryptor.setPassword(""); // 암호화 키
+        encryptor.setAlgorithm("PBEWithSHA256And128BitAES-CBC-BC"); // 알고리즘
+
+        return encryptor;
+    }
+}

--- a/auth-service/src/main/resources/application-dev.yml
+++ b/auth-service/src/main/resources/application-dev.yml
@@ -14,6 +14,21 @@ spring:
     port: 6379
     host: 127.0.0.1
     password: ''
+  mail:
+    host: smtp.naver.com
+    port: 465
+    username: ENC(cLCKOqMe9ppsanYddNRTcXN30dpRGKk42YUMZh3jmXGTZDyMws/OyJSxv1i95nye)
+    password: ENC(YCIUBoeyZYXbyS551Xy8JAhKYMtcTe4F1+LkabBbz0o=)
+    properties:
+      debug: true
+      mail:
+        smtp:
+          auth: true
+          ssl:
+            enable: true
+            trust: smtp.naver.com
+          starttls:
+            enable: true
   h2:
     console:
       enabled: true
@@ -29,3 +44,7 @@ token:
   #  1day
   refresh_expiration_time: 864000000
   secret: user_token
+
+jasypt:
+  encryptor:
+    bean: jasyptEncryptor


### PR DESCRIPTION
### 구현 내용
1. 메일 전송
  - API : POST /mail/send?email={보낼 이메일}
  - request : ``param key : email, value : {보낼 이메일}``
  - response : ``{certificateNumber}``
2. 인증코드 확인
  - API : GET /mail/check?code={사용자 입력 코드}
  - request : ``param key : email, value : {사용자 입력 코드}``
  - response : ``인증 완료``, 실패 시 500에러

### 특이 사항
- 메일 smtp사용을 위한 정보를 암호화 했기 때문에 사용하시려면 암호화 알고리즘 키를 요청하여 JasyptConfigAES의 알고리즘 키 부분에 넣어주세요!

close #4 