### PR TITLE
이력서 작성 및 조회기능 구현

### DIFF
--- a/auth-service/src/main/java/kr/ac/kumoh/whale/authservice/domain/member/dto/response/MemberInfoDto.java
+++ b/auth-service/src/main/java/kr/ac/kumoh/whale/authservice/domain/member/dto/response/MemberInfoDto.java
@@ -1,0 +1,30 @@
+package kr.ac.kumoh.whale.authservice.domain.member.dto.response;
+
+import kr.ac.kumoh.whale.authservice.domain.member.entity.Disability;
+import kr.ac.kumoh.whale.authservice.domain.member.entity.MemberEntity;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberInfoDto {
+    private String username;
+    private int age;
+    private String email;
+    private String addressInfo;
+    private String addressDetails;
+    private Disability disabilityType;
+
+    @Builder
+    public MemberInfoDto(MemberEntity memberEntity) {
+        this.username = memberEntity.getUsername();
+        this.email = memberEntity.getEmail();
+        this.age = memberEntity.getAge();
+        this.addressInfo = memberEntity.getAddressInfo();
+        this.addressDetails = memberEntity.getAddressDetails();
+        this.disabilityType = memberEntity.getDisabilityType();
+    }
+}

--- a/auth-service/src/main/java/kr/ac/kumoh/whale/authservice/domain/member/entity/MemberEntity.java
+++ b/auth-service/src/main/java/kr/ac/kumoh/whale/authservice/domain/member/entity/MemberEntity.java
@@ -1,5 +1,6 @@
 package kr.ac.kumoh.whale.authservice.domain.member.entity;
 
+import kr.ac.kumoh.whale.authservice.domain.resume.entity.ResumeEntity;
 import lombok.*;
 
 import javax.persistence.*;
@@ -42,6 +43,9 @@ public class MemberEntity {
     @Column(nullable = false)
     private Disability disabilityType;
 
+    @OneToOne(mappedBy = "member")
+    private ResumeEntity resume;
+
     @Builder
     public MemberEntity(@NonNull String username, @NonNull int age, @NonNull String email, @NonNull String encryptedPwd, @NonNull String addressInfo, @NonNull String addressDetails, @NonNull Disability disabilityType) {
         this.username = username;
@@ -51,5 +55,9 @@ public class MemberEntity {
         this.addressInfo = addressInfo;
         this.addressDetails = addressDetails;
         this.disabilityType = disabilityType;
+    }
+
+    public void writeResume(ResumeEntity resume){
+        resume.setMember(this);
     }
 }

--- a/auth-service/src/main/java/kr/ac/kumoh/whale/authservice/domain/resume/api/ResumeController.java
+++ b/auth-service/src/main/java/kr/ac/kumoh/whale/authservice/domain/resume/api/ResumeController.java
@@ -1,0 +1,32 @@
+package kr.ac.kumoh.whale.authservice.domain.resume.api;
+
+import kr.ac.kumoh.whale.authservice.domain.resume.dto.ResumeDto;
+import kr.ac.kumoh.whale.authservice.domain.resume.dto.ResumeRequest;
+import kr.ac.kumoh.whale.authservice.domain.resume.service.ResumeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/resumes")
+@RequiredArgsConstructor
+public class ResumeController {
+    private final ResumeService resumeService;
+
+    @PostMapping
+    public ResponseEntity<ResumeDto> writeResume(@RequestHeader("Authorization") String token,
+                                                 @RequestBody ResumeRequest resumeRequest) {
+        String accessToken = token.substring(7);
+        ResumeDto response = resumeService.createResume(accessToken, resumeRequest);
+
+        return ResponseEntity.ok().body(response);
+    }
+
+    @GetMapping
+    public ResponseEntity<ResumeDto> getResume(@RequestHeader("Authorization") String token) {
+        String accessToken = token.substring(7);
+        ResumeDto response = resumeService.getResume(accessToken);
+
+        return ResponseEntity.ok().body(response);
+    }
+}

--- a/auth-service/src/main/java/kr/ac/kumoh/whale/authservice/domain/resume/dto/CareerDto.java
+++ b/auth-service/src/main/java/kr/ac/kumoh/whale/authservice/domain/resume/dto/CareerDto.java
@@ -1,0 +1,22 @@
+package kr.ac.kumoh.whale.authservice.domain.resume.dto;
+
+import kr.ac.kumoh.whale.authservice.domain.resume.entity.Career;
+import kr.ac.kumoh.whale.authservice.domain.resume.entity.JobCategory;
+import kr.ac.kumoh.whale.authservice.domain.resume.entity.ResumeEntity;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CareerDto {
+
+    private int period;
+    private JobCategory category;
+
+    public CareerDto(Career career) {
+        this.period = career.getPeriod();
+        this.category = career.getCategory();
+    }
+}

--- a/auth-service/src/main/java/kr/ac/kumoh/whale/authservice/domain/resume/dto/ResumeDto.java
+++ b/auth-service/src/main/java/kr/ac/kumoh/whale/authservice/domain/resume/dto/ResumeDto.java
@@ -1,0 +1,32 @@
+package kr.ac.kumoh.whale.authservice.domain.resume.dto;
+
+import kr.ac.kumoh.whale.authservice.domain.resume.entity.*;
+import lombok.Data;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Data
+public class ResumeDto {
+    // 전공
+    private String major;
+    // 최종 학력
+    private Education education;
+    // 선호 연봉
+    private long preferIncome;
+    // 선호 근무 형태
+    private WorkType workType;
+    // 경력
+    private List<CareerDto> careerList;
+    // 자격증
+    private List<Certification> certifications;
+
+    public ResumeDto(ResumeEntity entity) {
+        this.major = entity.getMajor();
+        this.education = entity.getEducation();
+        this.preferIncome = entity.getPreferIncome();
+        this.workType = entity.getWorkType();
+        this.careerList = entity.getCareerList().stream().map(CareerDto::new).collect(Collectors.toList());
+        this.certifications = entity.getCertifications();
+    }
+}

--- a/auth-service/src/main/java/kr/ac/kumoh/whale/authservice/domain/resume/dto/ResumeRequest.java
+++ b/auth-service/src/main/java/kr/ac/kumoh/whale/authservice/domain/resume/dto/ResumeRequest.java
@@ -1,0 +1,20 @@
+package kr.ac.kumoh.whale.authservice.domain.resume.dto;
+
+import kr.ac.kumoh.whale.authservice.domain.resume.entity.Certification;
+import kr.ac.kumoh.whale.authservice.domain.resume.entity.Education;
+import kr.ac.kumoh.whale.authservice.domain.resume.entity.WorkType;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class ResumeRequest {
+    private String major;
+    private Education education;
+    private long preferIncome;
+    private WorkType workType;
+    private List<Certification> certifications;
+    private List<CareerDto> careers;
+}
+
+

--- a/auth-service/src/main/java/kr/ac/kumoh/whale/authservice/domain/resume/entity/Career.java
+++ b/auth-service/src/main/java/kr/ac/kumoh/whale/authservice/domain/resume/entity/Career.java
@@ -1,0 +1,36 @@
+package kr.ac.kumoh.whale.authservice.domain.resume.entity;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(name = "careers")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Career {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "career_id")
+    private Long id;
+    private int period;
+    private JobCategory category;
+
+    @ManyToOne
+    @JoinColumn(name = "resume_id", nullable = false)
+    private ResumeEntity resume;
+
+    @Builder
+    public Career(int period, JobCategory category) {
+        this.period = period;
+        this.category = category;
+    }
+
+    public void setResume(ResumeEntity resume){
+        this.resume = resume;
+    }
+}

--- a/auth-service/src/main/java/kr/ac/kumoh/whale/authservice/domain/resume/entity/Certification.java
+++ b/auth-service/src/main/java/kr/ac/kumoh/whale/authservice/domain/resume/entity/Certification.java
@@ -1,0 +1,19 @@
+package kr.ac.kumoh.whale.authservice.domain.resume.entity;
+
+public enum Certification {
+    JAVA("Java Certification"),
+    AWS("AWS Certification"),
+    PMP("Project Management Professional"),
+    CCNA("Cisco Certified Network Associate"),
+    CFA("Chartered Financial Analyst");
+
+    private final String displayName;
+
+    Certification(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+}

--- a/auth-service/src/main/java/kr/ac/kumoh/whale/authservice/domain/resume/entity/Education.java
+++ b/auth-service/src/main/java/kr/ac/kumoh/whale/authservice/domain/resume/entity/Education.java
@@ -1,0 +1,19 @@
+package kr.ac.kumoh.whale.authservice.domain.resume.entity;
+
+public enum Education {
+    HIGH_SCHOOL("High School"),
+    BACHELOR("Bachelor's Degree"),
+    MASTER("Master's Degree"),
+    DOCTORATE("Doctorate Degree");
+
+    private final String displayName;
+
+    Education(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+}
+

--- a/auth-service/src/main/java/kr/ac/kumoh/whale/authservice/domain/resume/entity/JobCategory.java
+++ b/auth-service/src/main/java/kr/ac/kumoh/whale/authservice/domain/resume/entity/JobCategory.java
@@ -1,0 +1,19 @@
+package kr.ac.kumoh.whale.authservice.domain.resume.entity;
+
+public enum JobCategory {
+    SOFTWARE_ENGINEER("Software Engineer"),
+    PRODUCT_MANAGER("Product Manager"),
+    DATA_SCIENTIST("Data Scientist"),
+    MARKETING_SPECIALIST("Marketing Specialist"),
+    FINANCIAL_ANALYST("Financial Analyst");
+
+    private final String displayName;
+
+    JobCategory(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+}

--- a/auth-service/src/main/java/kr/ac/kumoh/whale/authservice/domain/resume/entity/ResumeEntity.java
+++ b/auth-service/src/main/java/kr/ac/kumoh/whale/authservice/domain/resume/entity/ResumeEntity.java
@@ -1,0 +1,66 @@
+package kr.ac.kumoh.whale.authservice.domain.resume.entity;
+
+import kr.ac.kumoh.whale.authservice.domain.member.entity.MemberEntity;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.List;
+
+@Getter
+@Entity
+@Table(name = "resumes")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ResumeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "resume_id")
+    private Long id;
+
+    @OneToOne(cascade = CascadeType.ALL)
+    @JoinColumn(name = "member_id", unique = true, nullable = false)
+    private MemberEntity member;
+
+    // 전공
+    private String major;
+    // 최종 학력
+    private Education education;
+    // 선호 연봉
+    private long preferIncome;
+    // 선호 근무 형태
+    private WorkType workType;
+    // 경력
+    @OneToMany(mappedBy = "resume", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Career> careerList;
+    // 자격증
+    @ElementCollection
+    private List<Certification> certifications;
+
+    @Builder
+    public ResumeEntity(MemberEntity member, String major, Education education, long preferIncome, WorkType workType, List<Career> careerList, List<Certification> certifications) {
+        this.member = member;
+        this.major = major;
+        this.education = education;
+        this.preferIncome = preferIncome;
+        this.workType = workType;
+        this.careerList = careerList;
+        this.certifications = certifications;
+    }
+
+    public void addCareer(Career career){
+        career.setResume(this);
+        this.careerList.add(career);
+    }
+
+    public void setMember(MemberEntity member){
+        this.member = member;
+    }
+
+    public void setCareerList(List<Career> careers) {
+        for(Career career:careers){
+            this.addCareer(career);
+        }
+    }
+}

--- a/auth-service/src/main/java/kr/ac/kumoh/whale/authservice/domain/resume/entity/WorkType.java
+++ b/auth-service/src/main/java/kr/ac/kumoh/whale/authservice/domain/resume/entity/WorkType.java
@@ -1,0 +1,17 @@
+package kr.ac.kumoh.whale.authservice.domain.resume.entity;
+
+public enum WorkType {
+    FULL_TIME("Full-time"),
+    PART_TIME("Part-time"),
+    REMOTE("Remote");
+
+    private final String displayName;
+
+    WorkType(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+}

--- a/auth-service/src/main/java/kr/ac/kumoh/whale/authservice/domain/resume/repository/CareerRepository.java
+++ b/auth-service/src/main/java/kr/ac/kumoh/whale/authservice/domain/resume/repository/CareerRepository.java
@@ -1,0 +1,7 @@
+package kr.ac.kumoh.whale.authservice.domain.resume.repository;
+
+import kr.ac.kumoh.whale.authservice.domain.resume.entity.Career;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CareerRepository extends JpaRepository<Career, Long> {
+}

--- a/auth-service/src/main/java/kr/ac/kumoh/whale/authservice/domain/resume/repository/ResumeRepository.java
+++ b/auth-service/src/main/java/kr/ac/kumoh/whale/authservice/domain/resume/repository/ResumeRepository.java
@@ -1,0 +1,11 @@
+package kr.ac.kumoh.whale.authservice.domain.resume.repository;
+
+import kr.ac.kumoh.whale.authservice.domain.resume.entity.ResumeEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ResumeRepository extends JpaRepository<ResumeEntity, Long> {
+    Optional<ResumeEntity> findByMember_Email(String userEmail);
+    boolean existsByMember_Email(String userEmail);
+}

--- a/auth-service/src/main/java/kr/ac/kumoh/whale/authservice/domain/resume/service/ResumeService.java
+++ b/auth-service/src/main/java/kr/ac/kumoh/whale/authservice/domain/resume/service/ResumeService.java
@@ -1,0 +1,83 @@
+package kr.ac.kumoh.whale.authservice.domain.resume.service;
+
+
+import kr.ac.kumoh.whale.authservice.domain.member.entity.MemberEntity;
+import kr.ac.kumoh.whale.authservice.domain.member.repository.MemberRepository;
+import kr.ac.kumoh.whale.authservice.domain.resume.dto.CareerDto;
+import kr.ac.kumoh.whale.authservice.domain.resume.dto.ResumeDto;
+import kr.ac.kumoh.whale.authservice.domain.resume.dto.ResumeRequest;
+import kr.ac.kumoh.whale.authservice.domain.resume.entity.Career;
+import kr.ac.kumoh.whale.authservice.domain.resume.entity.ResumeEntity;
+import kr.ac.kumoh.whale.authservice.domain.resume.repository.ResumeRepository;
+import kr.ac.kumoh.whale.authservice.global.error.exception.EntityNotFoundException;
+import kr.ac.kumoh.whale.authservice.global.error.exception.InvalidValueException;
+import kr.ac.kumoh.whale.authservice.global.security.TokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class ResumeService {
+    private final ResumeRepository resumeRepository;
+    private final MemberRepository memberRepository;
+    private final TokenProvider tokenProvider;
+
+    @Transactional
+    public ResumeDto createResume(String token, ResumeRequest resumeRequest){
+        String userEmail = tokenProvider.validateJwtAndGetUserEmail(token);
+        MemberEntity member = memberRepository.findByEmail(userEmail)
+                .orElseThrow(()->new EntityNotFoundException("사용자를 찾을 수 없습니다."));
+        if (resumeRepository.existsByMember_Email(userEmail)){
+            throw new InvalidValueException("이미 이력서가 존재합니다");
+        }
+
+        ResumeEntity resume = ResumeEntity.builder()
+                .member(member)
+                .preferIncome(resumeRequest.getPreferIncome())
+                .workType(resumeRequest.getWorkType())
+                .education(resumeRequest.getEducation())
+                .major(resumeRequest.getMajor())
+                .careerList(new ArrayList<>())
+                .certifications(resumeRequest.getCertifications())
+                .build();
+
+        // 경력 생성 및 추가
+        List<Career> careers = new ArrayList<>();
+        for (CareerDto careerRequest : resumeRequest.getCareers()) {
+            Career career = Career.builder()
+                    .period(careerRequest.getPeriod())
+                    .category(careerRequest.getCategory())
+                    .build();
+            career.setResume(resume);
+            careers.add(career);
+        }
+        resume.setCareerList(careers);
+
+        ResumeEntity savedResume = resumeRepository.save(resume);
+
+        member.writeResume(resume);
+        memberRepository.save(member);
+
+        ResumeDto response = Optional.ofNullable(savedResume).map(ResumeDto::new)
+            .orElseThrow(()->new InvalidValueException("dto 변환 실패"));
+
+        return response;
+    }
+
+    public ResumeDto getResume(String accessToken) {
+        String userEmail = tokenProvider.validateJwtAndGetUserEmail(accessToken);
+        ResumeEntity resumeEntity = resumeRepository.findByMember_Email(userEmail)
+                .orElseThrow(()->new EntityNotFoundException("작성한 이력서를 찾을 수 없습니다."));
+
+        ResumeDto response = Optional.ofNullable(resumeEntity).map(ResumeDto::new)
+                .orElseThrow(()->new InvalidValueException("dto 변환 실패"));
+
+        return response;
+    }
+}


### PR DESCRIPTION
### 구현 내용
1. 이력서 작성
  - API ``POST /resumes`` 
  - request
    - access token
```json
{
  "major": "Computer Science",
  "education": "BACHELOR",
  "preferIncome": 50000,
  "workType": "FULL_TIME",
  "certifications": ["JAVA", "AWS"],
  "careers": [
    {
      "period": 3,
      "category": "SOFTWARE_ENGINEER"
    },
    {
      "period": 2,
      "category": "FINANCIAL_ANALYST"
    }
  ]
}
```
  - response
```json
{
    "major": "Computer Science",
    "education": "BACHELOR",
    "preferIncome": 50000,
    "workType": "FULL_TIME",
    "careerList": [
        {
            "period": 3,
            "category": "SOFTWARE_ENGINEER"
        },
        {
            "period": 2,
            "category": "FINANCIAL_ANALYST"
        }
    ],
    "certifications": [
        "JAVA",
        "AWS"
    ]
}
```
2. 이력서 조회
  - API ``GET /resumes``
  - request
    - access token
  - response
```json
{
    "major": "Computer Science",
    "education": "BACHELOR",
    "preferIncome": 50000,
    "workType": "FULL_TIME",
    "careerList": [
        {
            "period": 3,
            "category": "SOFTWARE_ENGINEER"
        },
        {
            "period": 2,
            "category": "FINANCIAL_ANALYST"
        }
    ],
    "certifications": [
        "JAVA",
        "AWS"
    ]
}
```

### 추가 사항
- 다음 내용은 enum타입으로 관리됨
  - WorkType
  - Certification
  - Education
  - JobCategory

close #8 